### PR TITLE
Disable gperf memory check to see if this causes test timeout issues

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -27,8 +27,8 @@ def RunUnitTest(env, target, source, timeout = 60):
     else:
         cmd = [test]
     ShEnv = {env['ENV_SHLIB_PATH']: 'build/lib',
-             'HEAPCHECK': 'normal',
-             'PPROF_PATH': 'build/bin/pprof',
+#            'HEAPCHECK': 'normal',
+#            'PPROF_PATH': 'build/bin/pprof',
              'DB_ITERATION_TO_YIELD': '1',
              'PATH': os.environ['PATH']}
     proc = subprocess.Popen(cmd, stdout=logfile, stderr=logfile, env=ShEnv)


### PR DESCRIPTION
Temporarily disable gperf checks for unit tests. I believe this freezes at times, causing tests to timeout.
